### PR TITLE
fix error

### DIFF
--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,14 +1,21 @@
-# Root logger option
-log4j.rootLogger=DEBUG, file, stdout
-# Direct log messages to a log file
-log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.File=./logs/ogv.log
-log4j.appender.file.MaxFileSize=10MB
-log4j.appender.file.MaxBackupIndex=10
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{dd-MM-yyyy HH:mm:ss} %-5p %c{1}:%L - %m%n
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{dd-MM-yyyy HH:mm:ss} %-5p %c{1}:%L - %m%n
+rootLogger.level=DEBUG
+rootLogger.appenderRefs=stdout, file
+rootLogger.appenderRef.stdout.ref=STDOUT
+rootLogger.appenderRef.file.ref=FILE
+
+appender.stdout.type=Console
+appender.stdout.name=STDOUT
+appender.stdout.layout.type=PatternLayout
+appender.stdout.layout.pattern=%d{dd-MM-yyyy HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+appender.file.type=RollingFile
+appender.file.name=FILE
+appender.file.fileName=./logs/ogv.log
+appender.file.filePattern=./logs/ogv-%d{MM-dd-yyyy}-%i.log.gz
+appender.file.layout.type=PatternLayout
+appender.file.layout.pattern=%d{dd-MM-yyyy HH:mm:ss} %-5p %c{1}:%L - %m%n
+appender.file.policies.type=Policies
+appender.file.policies.size.type=SizeBasedTriggeringPolicy
+appender.file.policies.size.size=10MB
+appender.file.strategy.type=DefaultRolloverStrategy
+appender.file.strategy.max=10


### PR DESCRIPTION
$ java -jar target/ogv-3.2.0-runnable.jar
Exception in thread "main" java.lang.ExceptionInInitializerError
        at ch.hsr.ogv.Main.main(Main.java:9)
Caused by: org.apache.logging.log4j.core.config.ConfigurationException: No type attribute provided for component log4j
        at org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder.createComponent(PropertiesConfigurationBuilder.java:362)
        at org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder.processRemainingProperties(PropertiesConfigurationBuilder.java:206)
        at org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder.build(PropertiesConfigurationBuilder.java:190)
        at org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory.getConfiguration(PropertiesConfigurationFactory.java:56)
        at org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory.getConfiguration(PropertiesConfigurationFactory.java:34)
        at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:544)
        at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:463)
        at org.apache.logging.log4j.core.config.ConfigurationFactory.getConfiguration(ConfigurationFactory.java:321)
        at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:778)
        at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:808)
        at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:311)
        at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:160)
        at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:48)
        at org.apache.logging.log4j.LogManager.getContext(LogManager.java:139)
        at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:138)
        at org.apache.logging.slf4j.Log4jLoggerFactory.getContext(Log4jLoggerFactory.java:58)
        at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:46)
        at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:32)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:363)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
        at ch.hsr.ogv.MainApp.<clinit>(MainApp.java:19)
        ... 1 more